### PR TITLE
fix rctrl assignment

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,9 @@ v2.0.0
 
 Unreleased
 ------------------
+Fixed
+- tcod.Key right-hand modifiers are now set independently at initialization,
+  instead of mirroring the left-hand modifier value
 
 6.0.3 - 2018-09-05
 ------------------

--- a/tcod/libtcodpy.py
+++ b/tcod/libtcodpy.py
@@ -262,9 +262,9 @@ class Key(_CDataWrapper):
         self.lalt = lalt
         self.lctrl = lctrl
         self.lmeta = lmeta
-        self.ralt = lalt
-        self.rctrl = lctrl
-        self.rmeta = lmeta
+        self.ralt = ralt
+        self.rctrl = rctrl
+        self.rmeta = rmeta
         self.shift = shift
 
     def __getattr__(self, attr):


### PR DESCRIPTION
`rctrl` will always mirror `lctrl` right now. here's a quick fix.

```
>>> import tcod
>>> g_key = tcod.Key(pressed=True, vk=tcod.KEY_CHAR, c=ord('g'), lctrl=True, rctrl=False)
>>> print(g_key.rctrl)
True
```