### PR TITLE
Adds testing newer python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,19 @@ matrix:
   - os: linux
     python: 3.5
     env: CC=gcc-8 CXX=g++-8
+  - os: linux
+    python: 3.6
+    env: CC=gcc-8 CXX=g++-8
+  - os: linux
+    python: 3.7
+    dist: xenial
+    sudo: required
+    env: CC=gcc-8 CXX=g++-8
+  - os: linux
+    python: nightly
+    dist: xenial
+    sudo: required
+    env: CC=gcc-8 CXX=g++-8
   - os: osx
     language: generic
     env: USE_OPENMP=true
@@ -28,6 +41,7 @@ matrix:
   - env: USE_OPENMP=true
   - python: pypy3.5
   - python: 2.7
+  - python: nightly
 
   fast_finish: true
 


### PR DESCRIPTION
Adds testing with following python versions:
- python 3.6
- python 3.7
- nightly build (allowed fail)

Both 3.6 and 3.7 pass in travis.