### PR TITLE
Use consistent whitespace in example code

### DIFF
--- a/examples/termbox/termbox.py
+++ b/examples/termbox/termbox.py
@@ -43,12 +43,12 @@ KEY_DELETE           = (0xFFFF-13)
 KEY_PGUP             = (0xFFFF-16)
 KEY_PGDN             = (0xFFFF-17)
 
-KEY_MOUSE_LEFT      =(0xFFFF-22)
-KEY_MOUSE_RIGHT      =(0xFFFF-23)
-KEY_MOUSE_MIDDLE      =(0xFFFF-24)
-KEY_MOUSE_RELEASE      =(0xFFFF-25)
-KEY_MOUSE_WHEEL_UP      =(0xFFFF-26)
-KEY_MOUSE_WHEEL_DOWN      =(0xFFFF-27)
+KEY_MOUSE_LEFT       = (0xFFFF-22)
+KEY_MOUSE_RIGHT      = (0xFFFF-23)
+KEY_MOUSE_MIDDLE     = (0xFFFF-24)
+KEY_MOUSE_RELEASE    = (0xFFFF-25)
+KEY_MOUSE_WHEEL_UP   = (0xFFFF-26)
+KEY_MOUSE_WHEEL_DOWN = (0xFFFF-27)
 
 KEY_CTRL_TILDE       = 0x00
 KEY_CTRL_2           = 0x00
@@ -146,21 +146,21 @@ OUTPUT_GRAYSCALE = 4
 EVENT_KEY        = 'KEYDOWN'
 # /--
 EVENT_RESIZE     = 2
-EVENT_MOUSE		= 3
+EVENT_MOUSE      = 3
 
 class Event:
-    """ Aggregate for Termbox Event structure """
-    type = None
-    ch = None
-    key = None
-    mod = None
-    width = None
-    height = None
-    mousex = None
-    mousey = None
+	""" Aggregate for Termbox Event structure """
+	type = None
+	ch = None
+	key = None
+	mod = None
+	width = None
+	height = None
+	mousex = None
+	mousey = None
 
-    def gettuple(self):
-         return (self.type, self.ch, self.key, self.mod, self.width, self.height, self.mousex, self.mousey)
+	def gettuple(self):
+		return (self.type, self.ch, self.key, self.mod, self.width, self.height, self.mousex, self.mousey)
 
 class Termbox:
 	def __init__(self, width=132, height=60):

--- a/examples/termbox/termbox.py
+++ b/examples/termbox/termbox.py
@@ -170,10 +170,10 @@ class Termbox:
 
 		try:
 			self.console = tdl.init(width, height)
-                except tdl.TDLException as e:
+		except tdl.TDLException as e:
 			raise TermboxException(e)
 
-                self.e = Event() # cache for event data
+		self.e = Event() # cache for event data
 
 		_instance = self
 
@@ -280,11 +280,11 @@ class Termbox:
 		else:
 			uch = None
 		"""
-                for e in tdl.event.get():
-                  # [ ] not all events are passed thru
-                  self.e.type = e.type
-                  if e.type == 'KEYDOWN':
-                    self.e.key = e.key
-                    return self.e.gettuple()
+		for e in tdl.event.get():
+			# [ ] not all events are passed thru
+			self.e.type = e.type
+			if e.type == 'KEYDOWN':
+				self.e.key = e.key
+				return self.e.gettuple()
 
 		#return (e.type, uch, e.key, e.mod, e.w, e.h, e.x, e.y)


### PR DESCRIPTION
This fixes the inconsistent whitespace in the example code that prevents it from running:

```
$ python termbox.py
  File "termbox.py", line 173
    except tdl.TDLException as e:
                                ^
TabError: inconsistent use of tabs and spaces in indentation
```