### PR TITLE
Check all SDL2 include locations.

### DIFF
--- a/build_libtcod.py
+++ b/build_libtcod.py
@@ -128,14 +128,19 @@ if sys.platform == "win32":
 elif sys.platform == "darwin":
     SDL2_INCLUDE = os.path.join(SDL2_PARSE_PATH, "Versions/A/Headers")
 else:
-    match = re.match(
-        r".*-I(\S+)",
+    matches = re.findall(
+        r"-I(\S+)",
         subprocess.check_output(
             ["sdl2-config", "--cflags"], universal_newlines=True
         ),
     )
-    assert match
-    SDL2_INCLUDE, = match.groups()
+    assert matches
+
+    SDL2_INCLUDE = None
+    for match in matches:
+        if os.path.isfile(os.path.join(match, 'SDL_stdinc.h')):
+            SDL2_INCLUDE = match
+    assert SDL2_INCLUDE
 
 if sys.platform == "win32":
     include_dirs.append(SDL2_INCLUDE)


### PR DESCRIPTION
On at least my FreeBSD 12 install, the sdl2-config command returns a
string containing multiple -I values. The existing regex pulls out the
last of these and assumes it's the right one; on my machine, we should
actually be looking under the first one. By iterating over all the -I
values the command returns, we can improve our confidence of actually
finding the SDL2 headers.