### PR TITLE
Made context.new visible in docs

### DIFF
--- a/tcod/context.py
+++ b/tcod/context.py
@@ -61,6 +61,7 @@ import tcod.tileset
 
 __all__ = (
     "Context",
+    "new",
     "new_window",
     "new_terminal",
     "SDL_WINDOW_FULLSCREEN",


### PR DESCRIPTION
I just saw that tcod.context.new was referenced multiple times in the tcod.context docs and it was nowhere to find. So I added new to __all__.