### PR TITLE
Add Linux AArch64 wheel build support

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -186,8 +186,14 @@ jobs:
 
   linux-wheels:
     runs-on: "ubuntu-20.04"
+    strategy:
+      matrix:
+        arch: ["x86_64", "aarch64"]
     steps:
       - uses: actions/checkout@v1
+      - name: Set up QEMU
+        if: ${{ matrix.arch == 'aarch64' }}
+        uses: docker/setup-qemu-action@v1
       - name: Checkout submodules
         run: |
           git submodule update --init --recursive --depth 1
@@ -204,10 +210,14 @@ jobs:
           python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_BUILD: cp36-* pp*
-          CIBW_ARCHS_LINUX: "x86_64"
-          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+          CIBW_ARCHS_LINUX: ${{ matrix.arch }}
+          CIBW_MANYLINUX_*_IMAGE: manylinux2014
           CIBW_MANYLINUX_PYPY_X86_64_IMAGE: manylinux2014
-          CIBW_BEFORE_ALL_LINUX: yum install -y SDL2-devel
+          CIBW_MANYLINUX_PYPY_AARCH64_IMAGE: manylinux2014
+          CIBW_BEFORE_ALL_LINUX: >
+            yum install -y epel-release &&
+            yum-config-manager --enable epel &&
+            yum install -y SDL2-devel
           CIBW_BEFORE_TEST: pip install numpy
           CIBW_TEST_COMMAND: python -c "import tcod"
       - name: Archive wheel


### PR DESCRIPTION
Added linux aarch64 wheel build support.
Related to https://github.com/libtcod/python-tcod/issues/112, @HexDecimal Could you please review this PR?